### PR TITLE
Adding install to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ clean:
 	-rm -f *.cm[dtio]*
 	-rm -f opam-doc
 	-rm -f *~ *.annot *.js *.css *.html
+	
+install: all
+	-mkdir -p ${BINDIR}
+	cp opam-doc ${BINDIR}/opam-doc
 
 opam-doc: opam_doc_config.cmo index.cmo gentyp.cmo doctree.cmo html_utils.cmo cmd_format.cmo generate.cmo driver.cmo
 	$(OCAMLFIND) ${OCAMLC} ${OCAMLCFLAGS} -linkpkg -o $@ $^

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BINDIR=./bin
+
 OCAMLC=ocamlc
 OCAMLLINK=ocamlc
 OCAMLLEX=ocamllex


### PR DESCRIPTION
@lpw25 please check this carefully. I have little idea what I'm going. I am adding a "install" to the Makefile so I can add this to opam-repo-dev and the opam file can say:

 build: [
 [make "all"]
 [make "install" "BINDIR=%{bin}%"]

I'll not sure this is the best way to go about it, I've just been copying the style from lpw25/bin-doc 
