### PR TITLE
Do not create the 'doc' switch on install but on first usage of opam-doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 OCAMLBUILD     ?= ocamlbuild
 OCAMLC         = $(shell which ocamlc)
 COMPILER      ?= system
-DOCBIN         = $(shell opam config var root)/doc/bin
 BIN            = $(shell opam config var bin)
 
 J?=4
@@ -20,12 +19,11 @@ bin-doc: src/bin-doc/*.mli src/bin-doc/*.ml
 	mv driver.native bin-doc
 
 install: scripts/ocamlc scripts/ocamlc.opt bin-doc opam-doc-index
-	opam switch doc -A $(COMPILER) --no-switch
-	sed -e "s+__OCAMLC__+${OCAMLC}+" < scripts/ocamlc > $(DOCBIN)/ocamlc
-	sed -e "s+__OCAMLC__+${OCAMLC}+" < scripts/ocamlc.opt > $(DOCBIN)/ocamlc.opt
-	chmod +x $(DOCBIN)/ocamlc
-	chmod +x $(DOCBIN)/ocamlc.opt
-	cp bin-doc $(DOCBIN)
+	sed -e "s+__OCAMLC__+${OCAMLC}+" < scripts/ocamlc > $(BIN)/opam-doc-ocamlc
+	sed -e "s+__OCAMLC__+${OCAMLC}+" < scripts/ocamlc.opt > $(BIN)/opam-doc-ocamlc.opt
+	chmod +x $(BIN)/opam-doc-ocamlc
+	chmod +x $(BIN)/opam-doc-ocamlc.opt
+	cp bin-doc $(BIN)
 	cp scripts/opam-doc-collect.sh $(BIN)/opam-doc-collect
 	cp scripts/opam-doc-create.sh $(BIN)/opam-doc-create
 	cp opam-doc-index $(BIN)/opam-doc-index

--- a/scripts/opam-doc.sh
+++ b/scripts/opam-doc.sh
@@ -15,7 +15,16 @@ case "$1" in
 esac
 
 PACKAGES=$*
+
 DOC=$(opam config var root)/doc/doc
+BIN=$(opam config var bin)
+BINDOC=$(opam config var root)/doc/bin
+
+# Creating a 'doc' switch if needed
+opam switch doc -A system
+cp ${BIN}/opam-doc-ocamlc ${BINDOC}/ocamlc
+cp ${BIN}/opam-doc-ocamlc.opt ${BINDOC}/ocamlc.opt
+cp ${BIN}/bin-doc ${BINDOC}/bin-doc
 
 # Install the packages and keep the build dirs
 echo "[1/4] Installing the packages"


### PR DESCRIPTION
This resolve the dead-lock of opam calling back opam.
