### PR TITLE
Handle duplicate module names more gracefully

### DIFF
--- a/scripts/opam-doc-collect.sh
+++ b/scripts/opam-doc-collect.sh
@@ -8,18 +8,6 @@ set -e
 BUILD_DIR=$(opam config var root)/doc/build
 DATA_DIR=$(opam config var root)/doc/data-doc
 
-calc_md5_for_file()
-{
-  if command -v md5 > /dev/null; then
-    md5=$(cat $1 | md5)
-  elif command -v md5sum > /dev/null ; then
-    md5=$(cat $1 | md5sum | awk '{print $1}')
-  else
-    echo "Neither md5 nor md5sum were found in the PATH"
-    exit 1
-  fi
-}
-
 IMPORTS=$(opam list -s)
 
 rm -rf ${DATA_DIR}
@@ -31,40 +19,9 @@ for pkg in ${PKGS}; do
   pkgname=$(basename $pkg)
   echo $pkgname
   mkdir ${DATA_DIR}/$pkgname
-  CMDS=$(find ${pkg} -type f -name \*.cmd)
-  for cmd in ${CMDS}; do
-    d=$(dirname $cmd)
-    calc_md5_for_file "$cmd";
-    f=$(basename $cmd .cmd)
-    mkdir ${DATA_DIR}/$pkgname/$md5
-    r=${DATA_DIR}/$pkgname/$md5/$f
-    cp $d/$f.cmd $r.cmd
-  done
-  CMDIS=$(find ${pkg} -type f -name \*.cmdi)
-  for cmdi in ${CMDIS}; do
-    d=$(dirname $cmdi)
-    calc_md5_for_file "$cmdi";
-    f=$(basename $cmdi .cmdi)
-    mkdir ${DATA_DIR}/$pkgname/$md5
-    r=${DATA_DIR}/$pkgname/$md5/$f
-    cp $d/$f.cmdi $r.cmdi
-  done
-  CMTS=$(find ${pkg} -type f -name \*.cmt)
-  for cmt in ${CMTS}; do
-    d=$(dirname $cmt)
-    calc_md5_for_file "$cmt";
-    f=$(basename $cmt .cmt)
-    mkdir ${DATA_DIR}/$pkgname/$md5
-    r=${DATA_DIR}/$pkgname/$md5/$f
-    cp $d/$f.cmt $r.cmt
-  done
-  CMTIS=$(find ${pkg} -type f -name \*.cmti)
-  for cmti in ${CMTIS}; do
-    d=$(dirname $cmti)
-    calc_md5_for_file "$cmti";
-    f=$(basename $cmti .cmti)
-    mkdir ${DATA_DIR}/$pkgname/$md5
-    r=${DATA_DIR}/$pkgname/$md5/$f
-    cp $d/$f.cmti $r.cmti
+  cd $pkg
+  FILES=$(find . -type f \( -name \*.cmd -o -name \*.cmdi -o -name \*.cmt -o -name \*.cmti \) )
+  for f in ${FILES}; do
+    cp --parents $f ${DATA_DIR}/$pkgname
   done
 done

--- a/scripts/opam-doc-create.sh
+++ b/scripts/opam-doc-create.sh
@@ -16,7 +16,13 @@ mkdir ${DOC_DIR}
 
 cd ${DOC_DIR}
 for pkg in ${PKGS}; do
-  fs="$(find ${DATA_DIR}/$pkg -type f)"
+  fs=""
+  depth=0
+  while find "${DATA_DIR}/$pkg" -mindepth $depth -maxdepth $depth -type d | grep -q '.'
+  do
+    depth=$((depth + 1))
+    fs+="$(find ${DATA_DIR}/$pkg -mindepth $depth -maxdepth $depth -type f)"
+  done
   if [ "$fs" != "" ]; then
     name=$(echo $pkg | awk -F. '{print $1}')
     echo "Generating documentation for $name"

--- a/src/bin-doc/printdoctree.ml
+++ b/src/bin-doc/printdoctree.ml
@@ -114,7 +114,22 @@ and class_field i ppf x =
 (* Type expressions for the module language *)
 
 and module_type i ppf x = 
-  line i ppf "MODULE_TYPE\n"
+  match x with
+    Dmty_ident -> 
+      line i ppf "Dmty_ident\n"
+  | Dmty_signature s ->
+      line i ppf "Dmty_signature\n";
+      signature (i+1) ppf s
+  | Dmty_functor(mt1, mt2) ->
+      line i ppf "Dmty_functor\n";
+      module_type (i+1) ppf mt1;
+      module_type (i+1) ppf mt2;
+  | Dmty_with mt ->
+      line i ppf "Dmty_with\n";
+      module_type (i+1) ppf mt
+  | Dmty_typeof me ->
+      line i ppf "Dmty_typeof\n";
+      module_expr (i+1) ppf me
 
 and signature i ppf x = list i signature_item ppf x
 
@@ -156,7 +171,26 @@ and signature_item i ppf x =
   | Dsig_stop -> line i ppf "Dsig_stop\n"
 
 and module_expr i ppf x = 
-  line i ppf "MODULE_EXPR\n"
+  match x with
+    Dmod_ident -> 
+      line i ppf "Dmod_ident\n"
+  | Dmod_structure s ->
+      line i ppf "Dmod_structure\n";
+      structure (i+1) ppf s
+  | Dmod_functor(mt, me) ->
+      line i ppf "Dmod_functor\n";
+      module_type (i+1) ppf mt;
+      module_expr (i+1) ppf me;
+  | Dmod_apply(me1, me2) ->
+      line i ppf "Dmod_apply\n";
+      module_expr (i+1) ppf me1;
+      module_expr (i+1) ppf me2;
+  | Dmod_constraint(me, mt) ->
+      line i ppf "Dmod_constraint\n";
+      module_expr (i+1) ppf me;
+      module_type (i+1) ppf mt;
+  | Dmod_unpack ->
+      line i ppf "Dmod_unpack\n"
 
 and structure i ppf x = list i structure_item ppf x
 

--- a/src/bin-doc/printdoctree.mli
+++ b/src/bin-doc/printdoctree.mli
@@ -1,10 +1,12 @@
 open Format
 open Doctree
 
+val module_type : int -> formatter -> module_type -> unit
 val signature :
   int -> formatter -> signature_item list -> unit
 val signature_item :
   int -> formatter -> signature_item -> unit
+val module_expr : int -> formatter -> module_expr -> unit
 val structure : int -> formatter -> structure -> unit
 val structure_item : int -> formatter -> structure_item -> unit
 val interface : int -> formatter -> interface -> unit

--- a/src/opam-doc-index/generate.ml
+++ b/src/opam-doc-index/generate.ml
@@ -1239,7 +1239,7 @@ and generate_module_expr local dmexpr tmexpr =
             Printf.eprintf "generate_module_expr: unpack mismatch\n%!";
             assert false
       end
-    | _, _ -> raise (Failure "generate_module_type: Mismatch")
+    | _, _ -> raise (Failure "generate_module_expr: Mismatch")
 
 (* Discards open, expands module_rec and process signature items  *)
 and generate_signature_item_list local dsig_items tsig_items =


### PR DESCRIPTION
We now give a specific message about duplicate module names, and we look through modules in breadth-first order to try and ensure the "most important" module with the same name is used. 
