### PR TITLE
Provide help if no supported server is available

### DIFF
--- a/scripts/opam-doc-serve.sh
+++ b/scripts/opam-doc-serve.sh
@@ -3,10 +3,28 @@
 
 DOC="$1"
 
-if [ "$DOC" = "" ]; then
+if [ -z "$DOC" ]; then
   DOC=$(opam config var root)/doc/doc
 fi
 
+function installed {
+  local cmd=$1
+  command -v ${cmd} >/dev/null
+}
+
+if installed cohttp-server-async; then
+  SERVER="cohttp-server-async -p 8000"
+elif installed cohttp-server; then
+  SERVER="cohttp-server -p 8000"
+elif installed python; then
+  SERVER="python -m SimpleHTTPServer"
+else
+  echo "No supported HTTP server found. Please install cohttp:"
+  echo "  opam install async cohttp"
+  echo
+  exit 1
+fi
+
 cd $DOC
-cohttp-server -p 8000 || true
-python -m SimpleHTTPServer 
+exec $SERVER 2>/dev/null
+


### PR DESCRIPTION
- Support latest cohttp which no longer seems to provide cohttp-server
  executable, only -async and -lwt versions.
- Redirect stderr to null to hide Python's ugly backtrace on Ctrl-C.
